### PR TITLE
Add toModifiers utility

### DIFF
--- a/src/bemify-test.js
+++ b/src/bemify-test.js
@@ -1,5 +1,7 @@
 import test from 'tape';
-import bemify from './bemify';
+import bemify, {
+  toModifiers
+} from './bemify';
 
 
 // Object classes
@@ -246,5 +248,22 @@ test('no classes - returns the block itself (curried)', (t) => {
   t.isEqual(bemify(block)({}), block);
   t.isEqual(bemify(block)([]), block);
   t.isEqual(bemify(block)(''), block);
+  t.end();
+});
+
+
+// Utilities
+
+test('converting to modifiers', (t) => {
+  const expected = ['--one', '--three', '--two']; // sorted
+  t.isEquivalent(toModifiers('one two three'), expected);
+  t.isEquivalent(toModifiers(['one', 'two', 'three']), expected);
+  t.isEquivalent(toModifiers({
+    'one': true,
+    'two': true,
+    'three': true,
+    'four': false,
+  }), expected);
+  t.isEquivalent(toModifiers('one', ['two'], { 'three': true }), expected);
   t.end();
 });

--- a/src/bemify.js
+++ b/src/bemify.js
@@ -32,13 +32,13 @@ const flattenReduce = (flat, item) => flat.concat(item);
 
 // Takes `classes` which may be one of several types and returns
 // an array of them with all falsy values filtered out.
-const normalizeSuffixes = (classes) => {
+const normalizeParts = (classes) => {
   let suffixes = [];
   if (isString(classes)) { suffixes = [classes]; }
-  if (isArray(classes)) { suffixes = classes.map(normalizeSuffixes); }
+  if (isArray(classes)) { suffixes = classes.map(normalizeParts); }
   if (isObject(classes)) { suffixes = truthyObjToArr(classes); }
   return suffixes
-    // flatten since `normalizeSuffixes` is recursive when `isArray`
+    // flatten since `normalizeParts` is recursive when `isArray`
     .reduce(flattenReduce, [])
     .map(splitClasses)
     // flatten since `splitClasses` could return nested arrays
@@ -61,7 +61,7 @@ const getElement = (block, suffixes) => {
 };
 
 const bemify = curry1((block, ...denormalizedSuffixes) => {
-  const suffixes = normalizeSuffixes(denormalizedSuffixes);
+  const suffixes = normalizeParts(denormalizedSuffixes);
   const element = getElement(block, suffixes);
   const prefix = (suffix) => `${element}${suffix}`;
   return [
@@ -74,3 +74,7 @@ const bemify = curry1((block, ...denormalizedSuffixes) => {
 });
 
 export default bemify;
+
+export const toModifiers = (...classes) => {
+  return normalizeParts(classes).map((c) => `--${c}`);
+};


### PR DESCRIPTION
This is useful for converting a undashed strings to `--`-prefixed
strings, which can be common when passing data around instead of
prefixing everything manually with `--`. I didn't create a
corresponding `toElements` since there should only ever be one; I don't
see a use case for it.